### PR TITLE
fix location of GraphqlAPIDemultiplexer import

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ We define app routing, as if they were app urls:
 
 ```python
 # app/routing.py
-from graphene_django_subscriptions.subscription import GraphqlAPIDemultiplexer
+from graphene_django_subscriptions.consumers import GraphqlAPIDemultiplexer
 from channels.routing import route_class
 from .graphql.subscriptions import UserSubscription, GroupSubscription
 

--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ We define app routing, as if they were app urls:
 .. code:: python
 
     # app/routing.py
-    from graphene_django_subscriptions.subscriptions import GraphqlAPIDemultiplexer
+    from graphene_django_subscriptions.consumers import GraphqlAPIDemultiplexer
     from channels.routing import route_class
     from .graphql.subscriptions import UserSubscription, GroupSubscription
 


### PR DESCRIPTION
This was recently changed, I guess. Hit this thing while developing. 